### PR TITLE
Voice for group chat

### DIFF
--- a/upload/index.js
+++ b/upload/index.js
@@ -238,13 +238,14 @@ class Upload {
 	 * Загрузка аудиосообщения
 	 *
 	 * @param {Object} params
+	 * @param {Boolean} params.groupVoice - для отправки аудиосообщения в групповом чате
 	 *
 	 * @return {Promise<Object>}
 	 */
 	voice (params) {
 		params.type = 'audio_message';
 
-		return this.doc(params);
+		return params.groupVoice ? this.wallDoc(params) : this.doc(params);
 	}
 
 	/**

--- a/upload/index.js
+++ b/upload/index.js
@@ -238,14 +238,13 @@ class Upload {
 	 * Загрузка аудиосообщения
 	 *
 	 * @param {Object} params
-	 * @param {Boolean} params.groupVoice - для отправки аудиосообщения в групповом чате
 	 *
 	 * @return {Promise<Object>}
 	 */
 	voice (params) {
 		params.type = 'audio_message';
 
-		return params.groupVoice ? this.wallDoc(params) : this.doc(params);
+		return params.group_id ? this.wallDoc(params) : this.doc(params);
 	}
 
 	/**


### PR DESCRIPTION
Для загрузки голосовых сообщений в группах необходимо использовать **getWallUploadServer**, вместо **getUploadServer**.

Передача в параметрах **groupVoice** дает возможность отправлять голосовые сообщения в групповом чате.

[Пруф](https://ru.stackoverflow.com/a/609941)