### PR TITLE
New docs upload method

### DIFF
--- a/api/methods.js
+++ b/api/methods.js
@@ -164,6 +164,7 @@ module.exports = [
 	'docs.getById',
 	'docs.getTypes',
 	'docs.getUploadServer',
+	'docs.getMessagesUploadServer',
 	'docs.getWallUploadServer',
 	'docs.save',
 	'docs.search',

--- a/upload/index.js
+++ b/upload/index.js
@@ -213,11 +213,11 @@ class Upload {
 			this.vk.api.docs.save,
 			['title', 'tags']
 		])
-		.then((photos) => photos[0]);
+		.then((docs) => docs[0]);
 	}
 
 	/**
-	 * Загрузка документов для последующей отправки документа на стену или личным сообщением
+	 * Загрузка документов для последующей отправки документа на стену
 	 *
 	 * @param {Object} params
 	 *
@@ -231,7 +231,25 @@ class Upload {
 			this.vk.api.docs.save,
 			['title', 'tags']
 		])
-		.then((photos) => photos[0]);
+		.then((docs) => docs[0]);
+	}
+	
+	/**
+	 * Загрузка документов для последующей отправки документа личным сообщением
+	 *
+	 * @param {Object} params
+	 *
+	 * @return {Promise<Object>}
+	 */
+	messageDoc (params) {
+		return this._conduct([
+			params,
+			'file',
+			this.vk.api.docs.getMessagesUploadServer,
+			this.vk.api.docs.save,
+			['title', 'tags']
+		])
+		.then((docs) => docs[0]);
 	}
 
 	/**
@@ -244,7 +262,7 @@ class Upload {
 	voice (params) {
 		params.type = 'audio_message';
 
-		return params.group_id ? this.wallDoc(params) : this.doc(params);
+		return this.messageDoc(params);
 	}
 
 	/**


### PR DESCRIPTION
https://vk.com/dev/bots_docs_2?f=3.2.%2B%D0%92%D0%BB%D0%BE%D0%B6%D0%B5%D0%BD%D0%B8%D1%8F

docs.getMessagesUploadServer - новый метод для загрузки документов в диалоги.
Принимает параметр peer_id (id получателя).
При использовании с токеном сообщества параметр peer_id обязателен, при использовании с токеном пользователя peer_id игнорируется, овнером остается загружающий.
При загрузке документа от лица сообщества, документу присваивается owner_id = peer_id. 
Лимиты на загрузку от лица сообщества (при указанном peer_id) сняты.

photos.getMessagesUploadServer -  теперь принимает параметр peer_id. Поведение метода аналогично поведению docs.getMessagesUploadServer.
Лимиты на загрузку от лица сообщества (при указанном peer_id) сняты.