### PR TITLE
Properly handle arguments in "send" method

### DIFF
--- a/longpoll/messages.js
+++ b/longpoll/messages.js
@@ -42,7 +42,11 @@ class BaseMessage {
 	 */
 	send (text, params = {}) {
 		if (typeof text === 'object') {
-			params = text;
+			if(text.attachment) {
+				params = text;
+			} else {
+				throw new Error('First parameter of function "send" must be a string or object with "attachment" property');
+			}
 		} else {
 			params.message = text;
 		}


### PR DESCRIPTION
Если я по невнимательности передавал вместо строки объект, то у меня возникала ошибка со стороны ВК:

> One of the parameters specified was missing or invalid: message is empty or invalid

Согласно документации параметр **message** обязательный, если в параметрах сообщения не передано **attachments** [ссыль](https://vk.com/dev/messages.send)
В PR я добавил обработку такого случая.