### PR TITLE
Fix using functions as updates condition

### DIFF
--- a/src/updates/index.js
+++ b/src/updates/index.js
@@ -167,7 +167,7 @@ export default class Updates {
 
 			const hasSome = conditions.some((condition) => {
 				if (typeof condition === 'function') {
-					return conditions(text, context);
+					return condition(text, context);
 				}
 
 				if (condition instanceof RegExp) {


### PR DESCRIPTION
Right now if a function is passed as a condition array is called as a function, resulting in TypeError.