### PR TITLE
Документация для replyMessage

### DIFF
--- a/docs/ru/api-reference/contexts/message.md
+++ b/docs/ru/api-reference/contexts/message.md
@@ -62,6 +62,14 @@ context.hasAttachments([type]); // => boolean
 context.hasText; // => boolean
 ```
 
+## hasReplyMessage
+
+Проверяет наличие сообщения, в ответ на которое отправлено текущее
+
+```js
+context.hasReplyMessage; // => boolean
+```
+
 ## hasForwards
 
 Проверяет наличие пересланных сообщений
@@ -220,6 +228,14 @@ context.createdAt; // => number
 
 ```js
 context.text; // => ?string
+```
+
+## replyMessage
+
+Возвращает сообщение, в ответ на которое отправлено текущее
+
+```js
+context.replyMessage; // => MessageReply[]
 ```
 
 ## forwards


### PR DESCRIPTION
Добавил документацию для `replyMessage` и `hasReplyMessage`
Сообщение на который был сделан ответ появляется в свойстве `reply_to` только в версии API начиная с 5.92, в версия ниже он будет добавлен в `forwards` как обычный пересел сообщения.