### PR TITLE
Небольшие исправления в контекстах сообщений и комментариев

### DIFF
--- a/packages/vk-io/src/api/schemas/params.ts
+++ b/packages/vk-io/src/api/schemas/params.ts
@@ -4236,6 +4236,7 @@ export interface MessagesSendParams {
     forward?: string;
     keyboard?: any;
     payload?: string;
+    template?: string;
     dont_parse_links?: boolean | number;
     disable_mentions?: boolean | number;
     [key: string]: any;

--- a/packages/vk-io/src/structures/contexts/comment-action.ts
+++ b/packages/vk-io/src/structures/contexts/comment-action.ts
@@ -8,6 +8,7 @@ import { Attachmentable } from '../shared/attachmentable';
 import { kSerializeData } from '../../utils/constants';
 import { transformAttachments } from '../attachments/helpers';
 import { pickProperties, applyMixins } from '../../utils/helpers';
+import { VK } from '../../vk';
 
 /**
  * Find types
@@ -283,17 +284,24 @@ class CommentActionContext<S = ContextDefaultState>
 
 	/**
 	 * Edits a comment
+   * 
+   * @param {object} options Options to pass to one of commentEdit methods
+   * @param {VK | undefined} fromUser VK Instance with user token. Useful if you got comment event from group and can't edit it.
+   * 
+   * @see https://vk.com/dev/wall.editComment 
 	 */
-	editComment(options: object): Promise<number> {
+	editComment(options: object, fromUser?: VK): Promise<number> {
 		if (this.isDelete) {
 			return Promise.reject(new VKError({
 				message: 'Comment is deleted',
 				code: 'ALREADY_DELETED'
 			}));
-		}
+    }
+    
+    const instance = fromUser ? fromUser : this.vk;
 
 		if (this.isBoardComment) {
-			return this.vk.api.board.editComment({
+			return instance.api.board.editComment({
 				...options,
 
 				comment_id: this.id,
@@ -310,19 +318,19 @@ class CommentActionContext<S = ContextDefaultState>
 		};
 
 		if (this.isPhotoComment) {
-			return this.vk.api.photos.editComment(params);
+			return instance.api.photos.editComment(params);
 		}
 
 		if (this.isVideoComment) {
-			return this.vk.api.video.editComment(params);
+			return instance.api.video.editComment(params);
 		}
 
 		if (this.isWallComment) {
-			return this.vk.api.wall.editComment(params);
+			return instance.api.wall.editComment(params);
 		}
 
 		if (this.isMarketComment) {
-			return this.vk.api.market.editComment(params);
+			return instance.api.market.editComment(params);
 		}
 
 		return Promise.reject(new VKError({
@@ -333,8 +341,12 @@ class CommentActionContext<S = ContextDefaultState>
 
 	/**
 	 * Removes comment
+   * 
+   * @param {VK | undefined} fromUser VK Instance with user token. Useful if you got comment event from group and can't edit it.
+   * 
+   * @see https://vk.com/dev/wall.deleteComment
 	 */
-	deleteComment(): Promise<number> {
+	deleteComment(fromUser?: VK): Promise<number> {
 		if (this.isDelete) {
 			return Promise.reject(new VKError({
 				message: 'Comment is deleted',
@@ -348,7 +360,9 @@ class CommentActionContext<S = ContextDefaultState>
 				topic_id: this.objectId,
 				group_id: this.$groupId!
 			});
-		}
+    }
+    
+    const instance = fromUser ? fromUser : this.vk;
 
 		const params = {
 			comment_id: this.id,
@@ -356,19 +370,19 @@ class CommentActionContext<S = ContextDefaultState>
 		};
 
 		if (this.isPhotoComment) {
-			return this.vk.api.photos.deleteComment(params);
+			return instance.api.photos.deleteComment(params);
 		}
 
 		if (this.isVideoComment) {
-			return this.vk.api.video.deleteComment(params);
+			return instance.api.video.deleteComment(params);
 		}
 
 		if (this.isWallComment) {
-			return this.vk.api.wall.deleteComment(params);
+			return instance.api.wall.deleteComment(params);
 		}
 
 		if (this.isMarketComment) {
-			return this.vk.api.market.deleteComment(params);
+			return instance.api.market.deleteComment(params);
 		}
 
 		return Promise.reject(new VKError({
@@ -396,11 +410,11 @@ class CommentActionContext<S = ContextDefaultState>
 			'isReply'
 		];
 
-		const filtredEmptyProperties = properties.filter(property => (
+		const filteredEmptyProperties = properties.filter(property => (
 			this[property] !== undefined
 		));
 
-		return pickProperties(this, filtredEmptyProperties);
+		return pickProperties(this, filteredEmptyProperties);
 	}
 }
 

--- a/packages/vk-io/src/structures/contexts/message.ts
+++ b/packages/vk-io/src/structures/contexts/message.ts
@@ -30,7 +30,7 @@ import {
 } from '../../utils/constants';
 import { AllowArray } from '../../types';
 import { UploadSource, UploadSourceValue } from '../../upload/upload';
-import { MessagesSendParams } from '../../../lib/api/schemas/params';
+import { MessagesSendParams } from '../../../src/api/schemas/params';
 
 export type MessageContextType = 'message';
 

--- a/packages/vk-io/src/types.ts
+++ b/packages/vk-io/src/types.ts
@@ -14,7 +14,7 @@ export interface IVKOptions {
 	/**
 	 * HTTPS agent
 	 *
-	 * @see {https://nodejs.org/api/https.html#https_class_https_agent}
+	 * @see https://nodejs.org/api/https.html#https_class_https_agent
 	 */
 	agent: Agent;
 
@@ -99,7 +99,7 @@ export interface IVKOptions {
 	/**
 	 * VK API version
 	 *
-	 * @see {https://vk.com/dev/versions}
+	 * @see https://vk.com/dev/versions
 	 */
 	apiVersion: string;
 

--- a/packages/vk-io/src/utils/helpers.ts
+++ b/packages/vk-io/src/utils/helpers.ts
@@ -119,7 +119,7 @@ export const pickProperties = <
 /**
  * Returns peer id type
  */
-export const getPeerType = (id: number): string => {
+export const getPeerType = (id: number): MessageSource => {
 	if (CHAT_PEER < id) {
 		return MessageSource.CHAT;
 	}


### PR DESCRIPTION
1. Добавлена возможность передавать в методы `context.editComment` и `context.deleteComment` дугой экземпляр VK IO, так-как эти методы не работают от имени группы.  
2. В MessageContext.clientInfo добавлены поля отвечающие за поддержку url кнопок и  карусели.  
3. Обновлена типизация хелпера `getPeerType` и методов в MessageContext, использующих его.  
4.  Обновлена типизация методов MessageContext'а для отправки чего-либо