### PR TITLE
fix #321

### DIFF
--- a/packages/vk-io/src/api/request.ts
+++ b/packages/vk-io/src/api/request.ts
@@ -41,7 +41,12 @@ export class APIRequest {
 		this.api = api;
 
 		this.method = method;
-		this.params = { ...params };
+		this.params = {
+			...Object.fromEntries(
+				Object.entries(params)
+					.filter(([, value]) => value !== undefined)
+			)
+		};
 
 		this.promise = new Promise((resolve, reject): void => {
 			this.resolve = resolve;


### PR DESCRIPTION
фиксит #321 (там подробности)

Повесил фильтр в конструктр APIRequest, тк я не думаю что ВК нужны параметры со значением `undefined`, особенно там, где он ожидает JSON.

Этот PR сильно облегчить ситуации, когда данные поступают из другого источника:
```ts
await ctx.send("Hey there!", {
    keyboard: await getKeyboardToSend() //undefined | KeyboardBuilder - соответствие типов, но ошибка в runtime от API
});
```

P.S. думаю это просто fix, без BREAKING CHANGE тк как мне кажется, это баг