### PR TITLE
fix(transform-message): parse attachments field with audio message

### DIFF
--- a/packages/vk-io/src/structures/contexts/helpers/transform-message.ts
+++ b/packages/vk-io/src/structures/contexts/helpers/transform-message.ts
@@ -59,16 +59,16 @@ const attachmentHandlers = {
 		};
 	},
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	doc: (raw: any, key: string): object => {
+	doc: (raw: any, key: string, _: string, index: number): object => {
 		const type = DocumentKind[raw[`${key}_kind`]] || AttachmentType.DOCUMENT;
 
 		return {
 			type,
-			[type]: idToAttachmentPayload(raw[key])
+			[type]: Object.keys(DocumentKind).includes(type)
+				? JSON.parse(raw.attachments)[index - 1]
+				: idToAttachmentPayload(raw[key])
 		};
 	},
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	audiomsg: (raw: any, key: string, type: string, index: number): object => JSON.parse(raw.attachments)[index - 1],
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	default: (raw: any, key: string, type: string): object => ({
 		type,
@@ -170,7 +170,7 @@ export function transformMessage({
 	message.attachments = [];
 
 	for (let i = 1, key = 'attach1'; attachments[key] !== undefined; i += 1, key = `attach${i}`) {
-		const type = attachments[`${key}_kind`] || attachments[`${key}_type`];
+		const type = attachments[`${key}_type`];
 
 		const handler = attachmentHandlers[type as keyof typeof attachmentHandlers]
 			|| attachmentHandlers.default;

--- a/packages/vk-io/src/structures/contexts/helpers/transform-message.ts
+++ b/packages/vk-io/src/structures/contexts/helpers/transform-message.ts
@@ -64,7 +64,7 @@ const attachmentHandlers = {
 
 		return {
 			type,
-			[type]: Object.keys(DocumentKind).includes(type)
+			[type]: DocumentKind[type]
 				? JSON.parse(raw.attachments)[index - 1]
 				: idToAttachmentPayload(raw[key])
 		};

--- a/packages/vk-io/src/structures/contexts/helpers/transform-message.ts
+++ b/packages/vk-io/src/structures/contexts/helpers/transform-message.ts
@@ -68,6 +68,8 @@ const attachmentHandlers = {
 		};
 	},
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	audiomsg: (raw: any, key: string, type: string, index: number): object => JSON.parse(raw.attachments)[index - 1],
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	default: (raw: any, key: string, type: string): object => ({
 		type,
 		[type]: idToAttachmentPayload(raw[key])
@@ -168,7 +170,7 @@ export function transformMessage({
 	message.attachments = [];
 
 	for (let i = 1, key = 'attach1'; attachments[key] !== undefined; i += 1, key = `attach${i}`) {
-		const type = attachments[`${key}_type`];
+		const type = attachments[`${key}_kind`] || attachments[`${key}_type`];
 
 		const handler = attachmentHandlers[type as keyof typeof attachmentHandlers]
 			|| attachmentHandlers.default;
@@ -177,7 +179,8 @@ export function transformMessage({
 			handler(
 				attachments,
 				key,
-				type
+				type,
+				i
 			)
 		);
 	}


### PR DESCRIPTION
Библиотека не обрабатывала поле `attachments` в событиях LongPoll, при отправке голосового сообщения там передается полный объект голосового сообщения.
Попытка загрузки вложения только по его id и id владельца может быть не всегда удачной, для голосовых сообщений также требуется `access_key`, которого нет в поле `attach{i}`.