### PR TITLE
Сделал поле `payload` в контексте публичным

### DIFF
--- a/packages/vk-io/src/structures/contexts/context.ts
+++ b/packages/vk-io/src/structures/contexts/context.ts
@@ -49,6 +49,7 @@ export class Context<
 
 	public $groupId?: number;
 
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	public payload: P & Record<string, any>;
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/vk-io/src/structures/contexts/context.ts
+++ b/packages/vk-io/src/structures/contexts/context.ts
@@ -49,7 +49,7 @@ export class Context<
 
 	public $groupId?: number;
 
-	protected payload: P;
+	public payload: P & Record<string, any>;
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	[key: string]: any;


### PR DESCRIPTION
Этот ПР упростит жизнь тем, кто работает с библиотекой на **TypeScript**, потому что типы контекстов (вернее геттеры в них) не  полноcтью покрывают те данные, которые передаёт API ВКонтакте.

**Пример**: `MarketOrderContext`. Мне требовалось **кол-во товаров, указанных в заказе**, а стандартный геттер `previewOrderItems` возвращал просто сущности товаров. Поэтому пришлось писать так:
```typescript
vk.updates.on("market_order_new", async ctx => {
  // ...
  const { preview_order_items } = (ctx as any).payload;
  // ...
});
```

Да, это костыль, но:
1) Он и так есть в JS
2) Нет доступных альтернатив
