### PR TITLE
chore(api): add new method groups

### DIFF
--- a/packages/vk-io/src/api/api.ts
+++ b/packages/vk-io/src/api/api.ts
@@ -64,7 +64,11 @@ const groupMethods = [
 	'widgets',
 	'junction',
 	'articles',
-	'donut'
+	'donut',
+	'specials',
+	'statEvents',
+	'loyaltyTeen',
+	'marusia'
 ];
 
 const workers: Record<string, Constructor<APIWorker>> = {


### PR DESCRIPTION
Расширил список доступных методов, типизацию для них не добавляем так как часть из них недоступна обычным пользователям.
Разработчики сами при необходимости смогут расширить типы через global.