### PR TITLE
fix complex objects in fetch params

### DIFF
--- a/packages/vk-io/src/api/request.ts
+++ b/packages/vk-io/src/api/request.ts
@@ -93,13 +93,16 @@ export class APIRequest {
 				signal: controller.signal,
 				headers: {
 					...options.apiHeaders,
-
 					connection: 'keep-alive'
 				},
-				body: new URLSearchParams(
-					Object.entries(params)
-						.filter(({ 1: value }) => value !== undefined)
-				)
+				body: new URLSearchParams(Object.entries(params)
+					.filter(i => i[1] !== undefined)
+					.map(i => {
+						if (typeof i[1] === 'object') {
+							i[1] = JSON.stringify(i[1])
+						}
+						return i
+					}))
 			});
 
 			const result = await response.json();


### PR DESCRIPTION
Исправил сериализацию сложных объектов, а то нет возможности отправить кнопки те же. Например следующий запрос в текущей версии отправляется 
```
{
      keyboard: {
        one_time: true,
        buttons: [
          [
            {
              action: {
                type: "text",
                label: "Red",
                payload: "{\"button\":\"4\"}"
              },
              color: "negative"
            },
            {
              action: {
                type: "text",
                label: "Green",
                payload: "{\"button\":\"4\"}"
              },
              color: "positive"
            }
          ]
        ]
      }
}
```

как `'keyboard=%5Bobject+Object%5D'`