### PR TITLE
@vk-io/authorization: разрешить кастомные заголовки при авторизации

### DIFF
--- a/packages/authorization/src/constants.ts
+++ b/packages/authorization/src/constants.ts
@@ -63,7 +63,11 @@ export const groupScopes = new Map<string, number>([
 export const officialAppCredentials = {
 	android: {
 		clientId: '2274003',
-		clientSecret: 'hHbZxrka2uZ6jB1inYsH'
+		clientSecret: 'hHbZxrka2uZ6jB1inYsH',
+		headers: {
+			// eslint-disable-next-line @typescript-eslint/naming-convention
+			'User-Agent': 'VKAndroidApp/7.7-10445 (Android 11; SDK 30; arm64-v8a; Xiaomi M2003J15SC; ru; 2340x1080)'
+		}
 	},
 	windows: {
 		clientId: '3697615',

--- a/packages/authorization/src/providers/account-verification.ts
+++ b/packages/authorization/src/providers/account-verification.ts
@@ -125,6 +125,7 @@ export class AccountVerification {
 
 		return this.fetchCookie(url, {
 			...options,
+			headers: this.options.headers,
 
 			agent,
 			signal: controller.signal,
@@ -137,8 +138,7 @@ export class AccountVerification {
 	 */
 	public async run(redirectUri: RequestInfo): Promise<{ userId: number; token: string }> {
 		let response = await this.fetch(redirectUri, {
-			method: 'GET',
-			headers: this.options.headers
+			method: 'GET'
 		});
 
 		const isProcessed = true;
@@ -239,8 +239,7 @@ export class AccountVerification {
 
 			const newResponse = await this.fetch(url, {
 				method: 'POST',
-				body: new URLSearchParams(fields),
-				headers: this.options.headers
+				body: new URLSearchParams(fields)
 			});
 
 			return newResponse;
@@ -290,8 +289,7 @@ export class AccountVerification {
 
 		const rewResponse = await this.fetch(url, {
 			method: 'POST',
-			body: new URLSearchParams(fields),
-			headers: this.options.headers
+			body: new URLSearchParams(fields)
 		});
 
 		if (rewResponse.url.includes(ACTION_SECURITY_CODE)) {
@@ -312,8 +310,7 @@ export class AccountVerification {
 		const url = getFullURL(href, response);
 
 		return this.fetch(url, {
-			method: 'GET',
-			headers: this.options.headers
+			method: 'GET'
 		});
 	}
 
@@ -359,8 +356,7 @@ export class AccountVerification {
 
 		const pageResponse = await this.fetch(url, {
 			method: 'POST',
-			body: new URLSearchParams(fields),
-			headers: this.options.headers
+			body: new URLSearchParams(fields)
 		});
 
 		return pageResponse;

--- a/packages/authorization/src/providers/account-verification.ts
+++ b/packages/authorization/src/providers/account-verification.ts
@@ -64,6 +64,7 @@ interface IAccountVerificationOptions {
 	phone?: string | number;
 
 	timeout?: number;
+	headers?: Record<string, string>;
 }
 
 export class AccountVerification {
@@ -87,6 +88,10 @@ export class AccountVerification {
 	public constructor(options: IAccountVerificationOptions) {
 		this.options = {
 			timeout: 10_000,
+			headers: options.headers || {
+				// eslint-disable-next-line @typescript-eslint/naming-convention
+				'User-Agent': DESKTOP_USER_AGENT
+			},
 
 			...options
 		};
@@ -114,8 +119,6 @@ export class AccountVerification {
 	protected fetch(url: RequestInfo, options: RequestInit = {}): Promise<Response> {
 		const { agent, timeout } = this.options;
 
-		const { headers = {} } = options;
-
 		const controller = new AbortController();
 
 		const interval = setTimeout(() => controller.abort(), timeout);
@@ -125,14 +128,7 @@ export class AccountVerification {
 
 			agent,
 			signal: controller.signal,
-			compress: false,
-
-			headers: {
-				...headers,
-
-				// eslint-disable-next-line @typescript-eslint/naming-convention
-				'User-Agent': DESKTOP_USER_AGENT
-			}
+			compress: false
 		}).finally(() => clearTimeout(interval));
 	}
 
@@ -141,7 +137,8 @@ export class AccountVerification {
 	 */
 	public async run(redirectUri: RequestInfo): Promise<{ userId: number; token: string }> {
 		let response = await this.fetch(redirectUri, {
-			method: 'GET'
+			method: 'GET',
+			headers: this.options.headers
 		});
 
 		const isProcessed = true;
@@ -242,7 +239,8 @@ export class AccountVerification {
 
 			const newResponse = await this.fetch(url, {
 				method: 'POST',
-				body: new URLSearchParams(fields)
+				body: new URLSearchParams(fields),
+				headers: this.options.headers
 			});
 
 			return newResponse;
@@ -292,7 +290,8 @@ export class AccountVerification {
 
 		const rewResponse = await this.fetch(url, {
 			method: 'POST',
-			body: new URLSearchParams(fields)
+			body: new URLSearchParams(fields),
+			headers: this.options.headers
 		});
 
 		if (rewResponse.url.includes(ACTION_SECURITY_CODE)) {
@@ -313,7 +312,8 @@ export class AccountVerification {
 		const url = getFullURL(href, response);
 
 		return this.fetch(url, {
-			method: 'GET'
+			method: 'GET',
+			headers: this.options.headers
 		});
 	}
 
@@ -359,7 +359,8 @@ export class AccountVerification {
 
 		const pageResponse = await this.fetch(url, {
 			method: 'POST',
-			body: new URLSearchParams(fields)
+			body: new URLSearchParams(fields),
+			headers: this.options.headers
 		});
 
 		return pageResponse;

--- a/packages/authorization/src/providers/direct.ts
+++ b/packages/authorization/src/providers/direct.ts
@@ -136,6 +136,7 @@ export class DirectAuthorization {
 
 		return this.fetchCookie(url, {
 			...options,
+			headers: this.options.headers,
 
 			agent,
 			signal: controller.signal,
@@ -186,8 +187,7 @@ export class DirectAuthorization {
 		const url = new URL(`https://oauth.vk.com/token?${params}`);
 
 		return this.fetch(url, {
-			method: 'GET',
-			headers: this.options.headers
+			method: 'GET'
 		});
 	}
 
@@ -449,8 +449,7 @@ export class DirectAuthorization {
 
 		const rewResponse = await this.fetch(url, {
 			method: 'POST',
-			body: new URLSearchParams(fields),
-			headers: this.options.headers
+			body: new URLSearchParams(fields)
 		});
 
 		if (rewResponse.url.includes(ACTION_SECURITY_CODE)) {


### PR DESCRIPTION
VK начали морозить аккаунты, если авторизоваться под учётками Android приложения без необходимого User Agent. Как временное решение могу предложить разрешить использование кастомных заголовков.