### PR TITLE
add support for upload params

### DIFF
--- a/packages/vk-io/src/upload/types.ts
+++ b/packages/vk-io/src/upload/types.ts
@@ -65,6 +65,11 @@ export interface IUploadConduct {
 	saveParams?: string[];
 
 	/**
+	 * Upload params
+	 */
+	uploadParams?: string[];
+
+	/**
 	 * Max uploaded files for one request
 	 */
 	maxFiles: number;

--- a/packages/vk-io/src/upload/upload.ts
+++ b/packages/vk-io/src/upload/upload.ts
@@ -905,11 +905,9 @@ export class Upload {
 			})
 		]);
 
-		const uploadParamsList = pickExistingProperties(params, uploadParams);
-		for (const key in uploadParamsList) {
-			if (Object.prototype.hasOwnProperty.call(uploadParamsList, key)) {
-				formData.append(key, uploadParamsList[key]);
-			}
+		const uploadParamsMap = pickExistingProperties(params, uploadParams);
+		for (const [key, value] of Object.entries(uploadParamsMap)) {
+			formData.append(key, value);
 		}
 
 		const uploaded = await this.upload(url, {

--- a/packages/vk-io/src/upload/upload.ts
+++ b/packages/vk-io/src/upload/upload.ts
@@ -857,6 +857,8 @@ export class Upload {
 		saveFiles,
 		saveParams = [],
 
+		uploadParams = [],
+
 		maxFiles = 1,
 		attachmentType
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -902,6 +904,13 @@ export class Upload {
 				attachmentType
 			})
 		]);
+
+		const uploadParamsList = pickExistingProperties(params, uploadParams);
+		for (const key in uploadParamsList) {
+			if (Object.prototype.hasOwnProperty.call(uploadParamsList, key)) {
+				formData.append(key, uploadParamsList[key]);
+			}
+		}
 
 		const uploaded = await this.upload(url, {
 			formData,


### PR DESCRIPTION
В некоторых случаях необходима передача дополнительных полей на URL-загрузки
Например, при загрузке фотографии профиля
![image](https://user-images.githubusercontent.com/45464902/212504543-ad22e531-d8cf-40cd-ac11-b68946331575.png)
