### PR TITLE
fix: type loading for ts 5.0 in ESM projects

### DIFF
--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -28,7 +28,8 @@
 	"exports": {
 		".": {
 			"import": "./lib/index.mjs",
-			"require": "./lib/index.js"
+			"require": "./lib/index.js",
+			"types": "./lib/index.d.ts"
 		}
 	},
 	"sideEffects": false,

--- a/packages/hear/package.json
+++ b/packages/hear/package.json
@@ -28,7 +28,8 @@
 	"exports": {
 		".": {
 			"import": "./lib/index.mjs",
-			"require": "./lib/index.js"
+			"require": "./lib/index.js",
+			"types": "./lib/index.d.ts"
 		}
 	},
 	"sideEffects": false,

--- a/packages/scenes/package.json
+++ b/packages/scenes/package.json
@@ -30,7 +30,8 @@
 	"exports": {
 		".": {
 			"import": "./lib/index.mjs",
-			"require": "./lib/index.js"
+			"require": "./lib/index.js",
+			"types": "./lib/index.d.ts"
 		}
 	},
 	"sideEffects": false,

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -28,7 +28,8 @@
 	"exports": {
 		".": {
 			"import": "./lib/index.mjs",
-			"require": "./lib/index.js"
+			"require": "./lib/index.js",
+			"types": "./lib/index.d.ts"
 		}
 	},
 	"sideEffects": false,

--- a/packages/stateless-prompt/package.json
+++ b/packages/stateless-prompt/package.json
@@ -29,7 +29,8 @@
 	"exports": {
 		".": {
 			"import": "./lib/index.mjs",
-			"require": "./lib/index.js"
+			"require": "./lib/index.js",
+			"types": "./lib/index.d.ts"
 		}
 	},
 	"sideEffects": false,

--- a/packages/streaming/package.json
+++ b/packages/streaming/package.json
@@ -28,7 +28,8 @@
 	"exports": {
 		".": {
 			"import": "./lib/index.mjs",
-			"require": "./lib/index.js"
+			"require": "./lib/index.js",
+			"types": "./lib/index.d.ts"
 		}
 	},
 	"sideEffects": false,

--- a/packages/vk-io/package.json
+++ b/packages/vk-io/package.json
@@ -32,7 +32,8 @@
 	"exports": {
 		".": {
 			"import": "./lib/index.mjs",
-			"require": "./lib/index.js"
+			"require": "./lib/index.js",
+			"types": "./lib/index.d.ts"
 		}
 	},
 	"sideEffects": false,


### PR DESCRIPTION
Сегодня я попытался написать бота на ESM с использованием typescript 5.0, как выяснилось, если декларации не указаны в `exports` в `package.json` он их не подгружает. Этот пр это чинит