### PR TITLE
Fixed MessageContext#delete; Added MessageEventContext#answerSnackbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3413,14 +3413,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
-    "node_modules/search-insights": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",

--- a/packages/vk-io/src/structures/contexts/message-event.ts
+++ b/packages/vk-io/src/structures/contexts/message-event.ts
@@ -101,6 +101,16 @@ export class MessageEventContext<S = ContextDefaultState> extends Context<
     }
 
     /**
+     * Show snackbar for user
+     */
+    public answerSnackbar(text: string): Promise<1> {
+        return this.answer({
+            type: "show_snackbar",
+            text
+        })
+    }
+
+    /**
      * Sends a message to the current dialog
      */
     async send(

--- a/packages/vk-io/src/structures/contexts/message.ts
+++ b/packages/vk-io/src/structures/contexts/message.ts
@@ -725,9 +725,11 @@ class MessageContext<S = ContextDefaultState> extends Context<
     async deleteMessage(options: Partial<Params.MessagesDeleteParams> = {}): Promise<boolean> {
         const isConversation = Boolean(this.conversationMessageId);
 
+        const cmid : number | undefined = this.conversationMessageId;
+
         const target = isConversation
-            ? { peer_id: this.peerId, cmids: this.conversationMessageId }
-            : { message_ids: this.id };
+            ? { peer_id: this.peerId, cmids: cmid ? [cmid] : cmid, delete_for_all: true }
+            : { message_ids: this.id, delete_for_all: true };
 
         const messageIds = await this.api.messages.delete({
             ...options,


### PR DESCRIPTION
[English]
1) Fixed method `delete` in MessageContext (its not working)
2) Added method `answerSnackbar` in MessageEventConext. Its allows sends snackbars in one line

[Русский]
1) Исправлен метод `delete` в классе MessageContext (он не работал)
2) Добавлен метод `answerSnackbar` в классе MessageEventContext. При помощи него можно отправлять snackbar в одну строчку